### PR TITLE
Fix python names of RSAPublicKey, DSAPublicKey

### DIFF
--- a/src/py_nss.c
+++ b/src/py_nss.c
@@ -7252,7 +7252,7 @@ PyRSAPublicKey_init(PyRSAPublicKey *self, PyObject *args, PyObject *kwds)
 
 static PyTypeObject PyRSAPublicKeyType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "nss.nss.PyRSAPublicKey",			/* tp_name */
+    "nss.nss.RSAPublicKey",			/* tp_name */
     sizeof(PyRSAPublicKey),			/* tp_basicsize */
     0,						/* tp_itemsize */
     (destructor)PyRSAPublicKey_dealloc,		/* tp_dealloc */
@@ -7477,7 +7477,7 @@ PyDSAPublicKey_init(PyDSAPublicKey *self, PyObject *args, PyObject *kwds)
 
 static PyTypeObject PyDSAPublicKeyType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "nss.nss.PyDSAPublicKey",			/* tp_name */
+    "nss.nss.DSAPublicKey",			/* tp_name */
     sizeof(PyDSAPublicKey),			/* tp_basicsize */
     0,						/* tp_itemsize */
     (destructor)PyDSAPublicKey_dealloc,		/* tp_dealloc */


### PR DESCRIPTION
In 079d4f65a743fb9e952ab109c1a24997c15398a7, I was a little greedy on my
find/replace and ended up adjusting the Python names of these structs as
well as the C names. We wish to keep the Python names the same, so
revert that part of the patch.

Credit to Stanislav Levin for finding and reporting this.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`